### PR TITLE
Fix typo in ListGroupItem

### DIFF
--- a/src/components/ListGroupItem.js
+++ b/src/components/ListGroupItem.js
@@ -6,7 +6,7 @@ export default {
     src: String,
     active: Boolean
   },
-  compouted: {
+  computed: {
     classes () {
       return { active: this.active }
     }


### PR DESCRIPTION
Fixes the typo "compouted" -> "computed" in ListGroupItem.js. This was causing the active binding to not work.